### PR TITLE
Add temperature publisher with Docker support

### DIFF
--- a/AI_AGENT_README.md
+++ b/AI_AGENT_README.md
@@ -1,0 +1,20 @@
+# AI Agent Documentation
+
+This project was created using Codex, an AI coding agent. The initial user
+prompt requested a Python application that periodically retrieves temperature
+information from Open-Meteo and publishes it via MQTT. The agent searched for
+any `AGENTS.md` instructions but none were found.
+
+The following steps were performed:
+
+1. Created `src/main.py` implementing the periodic temperature retrieval and
+   MQTT publishing.
+2. Added `requirements.txt` listing dependencies (`requests` and `paho-mqtt`).
+3. Added a `Dockerfile` to run the application in a container.
+4. Updated `README.md` with build and run instructions, including how to pass
+   configuration via environment variables and how to run automatically on
+   reboot using Docker's restart policy or a systemd unit.
+5. Documented these steps in this file for future reference.
+
+The prompts used were primarily the original user request in German to create
+this repository and provide all necessary documentation for running the tool.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src/ ./src/
+CMD ["python", "-u", "src/main.py"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
 # mqtt-temperature-publisher
-a codex / ai generated tool to publish open meteo temperatures to a mqtt broker
+
+This small Python application periodically retrieves the current temperature for a
+configurable location from the [Open-Meteo](https://open-meteo.com/) API and
+publishes it to a configurable MQTT topic.
+
+## Building the Docker image
+
+```
+docker build -t mqtt-temperature-publisher .
+```
+
+## Running
+
+The application is configured using environment variables:
+
+- `LATITUDE` – latitude of the location
+- `LONGITUDE` – longitude of the location
+- `MQTT_SERVER` – hostname or IP of the MQTT broker
+- `MQTT_PORT` – port of the MQTT broker (default: `1883`)
+- `MQTT_TOPIC` – topic to publish the temperature to (default: `temperature`)
+- `MQTT_USERNAME` – MQTT username
+- `MQTT_PASSWORD` – MQTT password
+- `INTERVAL_SECONDS` – interval between updates in seconds (default: `120`)
+
+Example run command:
+
+```
+docker run -d --restart unless-stopped \
+  -e LATITUDE=52.52 -e LONGITUDE=13.41 \
+  -e MQTT_SERVER=mqtt.example.com \
+  -e MQTT_PORT=1883 \
+  -e MQTT_TOPIC=home/temperature \
+  -e MQTT_USERNAME=user -e MQTT_PASSWORD=secret \
+  mqtt-temperature-publisher
+```
+
+The `--restart unless-stopped` flag ensures the container is restarted
+automatically on system reboot.
+
+## Running on another server automatically at boot
+
+When using Docker, the simplest way is to run the container with the
+`--restart unless-stopped` flag as shown above. Docker will then start the
+container on boot. If Docker is not available, you can install Docker and use
+systemd to manage the container, for example via a systemd unit:
+
+```
+[Unit]
+Description=MQTT Temperature Publisher
+After=docker.service
+Requires=docker.service
+
+[Service]
+Restart=always
+ExecStart=/usr/bin/docker run --rm \
+  -e LATITUDE=52.52 -e LONGITUDE=13.41 \
+  -e MQTT_SERVER=mqtt.example.com \
+  -e MQTT_PORT=1883 \
+  -e MQTT_TOPIC=home/temperature \
+  -e MQTT_USERNAME=user -e MQTT_PASSWORD=secret \
+  --name mqtt-temp mqtt-temperature-publisher
+ExecStop=/usr/bin/docker stop mqtt-temp
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable the unit with `systemctl enable your-unit.service` to start it
+automatically.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+paho-mqtt

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,50 @@
+import os
+import time
+import requests
+import paho.mqtt.client as mqtt
+
+
+def get_env(name, default=None, required=False):
+    value = os.getenv(name, default)
+    if required and value is None:
+        raise ValueError(f"Missing required environment variable {name}")
+    return value
+
+
+def fetch_temperature(latitude: str, longitude: str) -> float:
+    url = (
+        "https://api.open-meteo.com/v1/forecast?"
+        f"latitude={latitude}&longitude={longitude}&current_weather=true"
+    )
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    return data["current_weather"]["temperature"]
+
+
+def main():
+    lat = get_env("LATITUDE", required=True)
+    lon = get_env("LONGITUDE", required=True)
+    mqtt_server = get_env("MQTT_SERVER", required=True)
+    mqtt_port = int(get_env("MQTT_PORT", 1883))
+    mqtt_topic = get_env("MQTT_TOPIC", "temperature")
+    mqtt_username = get_env("MQTT_USERNAME", required=True)
+    mqtt_password = get_env("MQTT_PASSWORD", required=True)
+    interval = int(get_env("INTERVAL_SECONDS", 120))
+
+    client = mqtt.Client()
+    client.username_pw_set(mqtt_username, mqtt_password)
+    client.connect(mqtt_server, mqtt_port, 60)
+
+    while True:
+        try:
+            temperature = fetch_temperature(lat, lon)
+            client.publish(mqtt_topic, payload=temperature)
+            print(f"Published temperature {temperature} to {mqtt_topic}")
+        except Exception as exc:
+            print(f"Error during publish: {exc}")
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python script to fetch temperature from Open-Meteo and publish to MQTT
- provide Dockerfile and dependencies
- document build and run instructions
- document agent process in AI_AGENT_README

## Testing
- `python -m py_compile src/main.py`
- *(fails: ModuleNotFoundError: No module named 'requests')*